### PR TITLE
updated mathjax link to new cdn

### DIFF
--- a/projects/615/xkcd/index.html
+++ b/projects/615/xkcd/index.html
@@ -8,7 +8,7 @@
 
 
 <!-- MathJax scripts -->
-<script type="text/javascript" src="https://c328740.ssl.cf1.rackcdn.com/mathjax/2.0-latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/2.0-latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 
 


### PR DESCRIPTION
Mathjax CDN for SSL changed on July 31, 2014. This commit updates the mathjax link to the new CDN url.

See the following link for more information:
http://www.mathjax.org/changes-to-the-mathjax-cdn/
